### PR TITLE
Add 15 and 30 second intervals

### DIFF
--- a/color-tools.groovy
+++ b/color-tools.groovy
@@ -122,31 +122,51 @@ private scheduleHandler(handlerName, frequency, recurring = true) {
     unschedule(handlerName);
     if( frequency && recurring ) {
         debug("Scheduling ${handlerName} every ${frequency} minutes");
-        switch(Integer.parseInt(frequency)) {
-            case 1:
-                runEvery1Minute(handlerName);
-                break;
-            case 5:
-                runEvery5Minutes(handlerName);
-                break;
-            case 10:
-                runEvery10Minutes(handlerName);
-                break;
-            case 15:
-                runEvery15Minutes(handlerName);
-                break;
-            case 30:
-                runEvery30Minutes(handlerName);
-                break;
-            case 60:
-                runEvery1Hour(handlerName);
-                break;
-            case 180:
-                runEvery3Hours(handlerName);
-                break;
-            default:
-                log.error "Invalid frequency: ${frequency.inspect()}";
+        def dFreq = Double.parseDouble(frequency);
+        if (dFreq < 1 ) {
+            runEvery1Minute(runHandler, [data: [
+                handlerName: handlerName,
+                interval: (int) (1.0/dFreq)
+            ]]);
         }
+        else {
+            switch(Integer.parseInt(frequency)) {
+                case 1:
+                    runEvery1Minute(handlerName);
+                    break;
+                case 5:
+                    runEvery5Minutes(handlerName);
+                    break;
+                case 10:
+                    runEvery10Minutes(handlerName);
+                    break;
+                case 15:
+                    runEvery15Minutes(handlerName);
+                    break;
+                case 30:
+                    runEvery30Minutes(handlerName);
+                    break;
+                case 60:
+                    runEvery1Hour(handlerName);
+                    break;
+                case 180:
+                    runEvery3Hours(handlerName);
+                    break;
+                default:
+                    log.error "Invalid frequency: ${frequency.inspect()}";
+            }
+        }
+    }
+    this."${handlerName}"()
+}
+
+private runHandler(data) {
+    def handlerName = data.handlerName;
+    def interval = data.interval;
+    def total = interval;
+    while (total < 60) {
+        runIn(total, handlerName);
+        total += interval;
     }
     this."${handlerName}"()
 }
@@ -226,6 +246,18 @@ def doLightUpdate(devices, colorIndices, prefix = "") {
         }
     }
 }
+
+@Field static final List FREQ_OPTIONS = [
+    0.25: "15 seconds",
+    0.5: "30 seconds",
+    1: "1 minute",
+    5: "5 minutes",
+    10: "10 minutes",
+    15: "15 minutes",
+    30: "30 minutes",
+    60: "1 hour",
+    180: "3 hours"
+]
 
 @Field static final Map COLORS = [
     "Choose a Preset": "",

--- a/color-tools.groovy
+++ b/color-tools.groovy
@@ -247,7 +247,7 @@ def doLightUpdate(devices, colorIndices, prefix = "") {
     }
 }
 
-@Field static final List FREQ_OPTIONS = [
+@Field static final Map FREQ_OPTIONS = [
     0.25: "15 seconds",
     0.5: "30 seconds",
     1: "1 minute",
@@ -257,7 +257,7 @@ def doLightUpdate(devices, colorIndices, prefix = "") {
     30: "30 minutes",
     60: "1 hour",
     180: "3 hours"
-]
+];
 
 @Field static final Map COLORS = [
     "Choose a Preset": "",

--- a/color-tools.groovy
+++ b/color-tools.groovy
@@ -120,13 +120,14 @@ private drawColorSection(prefix, color, index) {
 
 private scheduleHandler(handlerName, frequency, recurring = true) {
     unschedule(handlerName);
+    unschedule("runHandler");
     if( frequency && recurring ) {
         debug("Scheduling ${handlerName} every ${frequency} minutes");
         def dFreq = Double.parseDouble(frequency);
         if (dFreq < 1 ) {
-            runEvery1Minute(runHandler, [data: [
+            runEvery1Minute("runHandler", [data: [
                 handlerName: handlerName,
-                interval: (int) (1.0/dFreq)
+                interval: (int) (60 * dFreq)
             ]]);
         }
         else {
@@ -157,18 +158,19 @@ private scheduleHandler(handlerName, frequency, recurring = true) {
             }
         }
     }
-    this."${handlerName}"()
+    else {
+        this."${handlerName}"()
+    }
 }
 
 private runHandler(data) {
     def handlerName = data.handlerName;
     def interval = data.interval;
-    def total = interval;
-    while (total < 60) {
-        runIn(total, handlerName);
-        total += interval;
-    }
-    this."${handlerName}"()
+    debug "Running ${handlerName} on interval ${interval}";
+    def delays = 0.step(60, interval) {
+        debug("Running ${handlerName} in ${it} seconds");
+        runIn(it, handlerName, [overwrite: false]);
+    };
 }
 
 private getColors(colorIndices, desiredLength, prefix = "") {

--- a/color-tools.groovy
+++ b/color-tools.groovy
@@ -158,9 +158,7 @@ private scheduleHandler(handlerName, frequency, recurring = true) {
             }
         }
     }
-    else {
-        this."${handlerName}"()
-    }
+    this."${handlerName}"()
 }
 
 private runHandler(data) {

--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -36,15 +36,7 @@ Map mainPage() {
             if(thisName) app.updateLabel("$thisName")
 
             input "frequency", "enum", title: "Update Frequency",
-                options: [
-                    1: "1 minute",
-                    5: "5 minutes",
-                    10: "10 minutes",
-                    15: "15 minutes",
-				    30: "30 minutes",
-				    60: "1 hour",
-				    180: "3 hours"
-                ], required: true
+                options: FREQ_OPTIONS, required: true
 
             def descr = "Choose which RGB/RGB bulbs to use"
             def deviceIndices = state.deviceIndices;

--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -679,7 +679,7 @@ private testHoliday(index) {
     beginHolidayPeriod();
     if( settings["holiday${currentHoliday}Display"] != STATIC ) {
         [15, 30, 45].each {
-            runIn(it, "doLightUpdate");
+            runIn(it, "conditionalLightUpdate", [overwrite: false]);
         }
     }
     runIn(60, "beginStateMachine");
@@ -737,7 +737,7 @@ private conditionalLightUpdate() {
 private endHolidayPeriod() {
     debug("Not in holiday period");
     state.currentHoliday = null;
-    unschedule("doLightUpdate");
+    unschedule("conditionalLightUpdate");
     lightsOff();
 }
 

--- a/palette-scene-instance.groovy
+++ b/palette-scene-instance.groovy
@@ -62,15 +62,7 @@ def pageColorSelect() {
             }
             displayOptions()
             input "frequency", "enum", title: "Update Frequency",
-                options: [
-                    1: "1 minute",
-                    5: "5 minutes",
-                    10: "10 minutes",
-                    15: "15 minutes",
-				    30: "30 minutes",
-				    60: "1 hour",
-				    180: "3 hours"
-                ], required: true
+                options: FREQ_OPTIONS, required: true
             input "debugSpew", "bool", title: "Log debug messages?",
                 submitOnChange: true, defaultValue: getParent().debugSpew();
 


### PR DESCRIPTION
Several people have requested shorter intervals than the built-in `RunEveryXMinutes()` functions supports. This uses `RunEveryMinute()` to run an intermediate step that schedules multiple runs over the upcoming minute.