### PR TITLE
Keep random from repeating

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ devices, you have full control of when this color palette starts and stops.
 * [7/18/2022]   Add support for Modes as an alternative to time period
 * [11/30/2022]  Moved code into library; new app Palette Scenes added
 * [12/14/2022]   HL: Permit setting behavior when illumination not triggered
+* [12/16/2022]  Added check for random producing identical output

--- a/color-tools.groovy
+++ b/color-tools.groovy
@@ -221,7 +221,15 @@ private getColors(colorIndices, desiredLength, prefix = "") {
         debug("Starting from offset ${offset} (next is ${state.sequentialIndex})");
     }
     def subList = result[offset..<(offset + desiredLength)];
+    def reshuffles = 0;
+    while( colors.size() > 1 && mode == RANDOM && subList == state.lastColors && reshuffles < 10) {
+        reshuffles++;
+        debug("Colors are the same as last time; shuffling and trying again");
+        Collections.shuffle(result);
+        subList = result[offset..<(offset + desiredLength)];
+    }
     debug("Sublist: ${subList.inspect()}");
+    state.lastColors = subList;
     return subList;
 }
 

--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -350,11 +350,8 @@ def pageColorSelect(params) {
             paragraph "Static means that the colors will be applied to the lights once " +
             "and will not change.  Otherwise, a new set of colors will " +
             "be applied to the lights every ${freqString}. " +
-            "Random shuffles the colors between lights each time; if you have few colors " +
-            "and few lights, or if you opt to show a single color at a time, " +
-            "the result may be the same as the previous iteration and appear not to change. " +
-            "Sequential means that the colors will advance through the colors strictly in order, which " +
-            "may work better if the order matters or you only have 1-2 lights."
+            "Random shuffles the colors between lights each time, attempting to avoid repeats. " +
+            "Sequential means that the colors will advance through the colors strictly in order."
         }
         section("Display Options") {
             displayOptions("holiday${i}");

--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -812,6 +812,7 @@ private conditionalLightUpdate() {
 private endHolidayPeriod() {
     debug("Not in holiday period");
     state.currentHoliday = null;
+    state.lastColors = null;
     unschedule("conditionalLightUpdate");
     unschedule("runHandler");
     determineNextLightMode();

--- a/palette-scene-instance.groovy
+++ b/palette-scene-instance.groovy
@@ -152,6 +152,7 @@ void deactivatePalette(evt) {
     unschedule("relayLightUpdate");
     unschedule("runHandler");
     unsubscribe(getControlSwitch(), "switch.off");
+    state.lastColors = null;
     parent.getRgbDevices()*.off();
 }
 


### PR DESCRIPTION
I had previously considered restricting what options could be selected to avoid repeats, but this might be a simpler fix -- remember the last decision and reshuffle if we have a collision.