### PR TITLE
Don't turn on switch if triggered by switch

### DIFF
--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -841,7 +841,7 @@ private unscheduleLightUpdate() {
 }
 
 private beginIlluminationPeriod(event = null) {
-    if( illuminationSwitch && event?.device?.getDeviceNetworkId() == illuminationSwitch?.getDeviceNetworkId() ) {
+    if( illuminationSwitch?.getDeviceNetworkId() != null && event?.device?.getDeviceNetworkId() == illuminationSwitch?.getDeviceNetworkId() ) {
         if( !state.illuminationMode ) {
             state.lockIllumination = true;
         }

--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -889,7 +889,12 @@ private endIlluminationPeriod() {
 private triggerIllumination(event = null) {
     debug("Illumination triggered" + (event ? " after ${event.device} sent ${event.value}" : ""));
     state.illuminationMode = true;
-    illuminationSwitch?.on();
+    if( !state.lockIllumination ) {
+        // If we're locked, it's because the switch is already on.
+        // Latent BUGBUG if we support multiple illumination switches
+        // in the future.
+        illuminationSwitch?.on();
+    }
     applyIlluminationSettings("triggered");
     otherIlluminationSwitches*.on();
 


### PR DESCRIPTION
If the illumination switch is a dimmer, it might fade to off and produce spurious `switch.on` events.  Try to minimize the impact by not sending `on()` commands back to switches that report being on, so we don't prevent the following `switch.off` event.