### PR TITLE
Check for enter/exit holiday period on mode change

### DIFF
--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -814,12 +814,17 @@ private testHoliday(index) {
 
 private onModeChange(evt) {
     debug("Mode changed to ${location.getMode().toString()}");
+    if( duringHolidayPeriod() ) {
+        beginHolidayPeriod();
+    }
+    else {
+        endHolidayPeriod();
+    }
+
     if( duringIlluminationPeriod() ) {
         beginIlluminationPeriod();
     }
     else {
-        // End Illumination will check for active holiday; no need to
-        // handle that case explicitly.
         endIlluminationPeriod();
     }
 }


### PR DESCRIPTION
When I rearchitected to make all decisions live in `determineNextLightMode()`, some of the checks that previously happened in the `endIllumination()` path no longer occurred.  This change explicitly checks for holiday status on mode changes, which should correct bugs around mode-only holiday periods.

Note that this will cause `determineNextLightMode()` to execute twice on mode changes, which could cause some race conditions or brief flashes of another configuration than expected.