### PR TITLE
Single colors are STATIC even if something else is selected

### DIFF
--- a/color-tools.groovy
+++ b/color-tools.groovy
@@ -260,14 +260,18 @@ def doLightUpdate(devices, colorIndices, prefix = "") {
     );
 
     // Apply the colors to the devices.
-    def delays = generateDelays(prefix, devices.size());
+    def delays = colorIndices.size() > 1 ?
+                    generateDelays(prefix, devices.size()) :
+                    (0..<devices.size()).collect{ 0 };
     [
         devices,
         colors,
         delays
     ].transpose().
       collectMany{
-        def innerDelays = generateDelays(prefix, it[0].size());
+        def innerDelays = colorIndices.size() > 1 ?
+                            generateDelays(prefix, it[0].size()) :
+                            (0..<it[0].size()).collect{ 0 };
         [
             it[0],
             innerDelays

--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -950,6 +950,7 @@ private determineNextLightMode() {
                 def handlerName = "conditionalLightUpdate";
                 scheduleHandler(handlerName, frequency,
                     settings["holiday${currentHoliday}Display"] != STATIC &&
+                        state.colorIndices["${state.currentHoliday}"].size() > 1 &&
                         !state.test
                 );
                 switchesForHoliday*.on();


### PR DESCRIPTION
Mostly an annoyance fix.  If you select a color rotation option other than STATIC but have a single color for a holiday, existing code will still run every X seconds/minutes to select new colors -- and pick the same color, because there's only one possible outcome. This change attempts to treat a single color as identical to STATIC even if something else was selected.