### PR TITLE
Don't time-bound holiday with modes

### DIFF
--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -1250,10 +1250,25 @@ private startFixedSchedules() {
 
 // #region Time Helper Functions
 
+private getMaxTimePeriod(prefix, startStop) {
+    def modesActive = (settings["${prefix}Modes"]?.size() ?: 0) > 0;
+    def time = getLocalTime("${prefix}${startStop}");
+    if( time && !modesActive ) {
+        return time;
+    }
+    else {
+        return startStop == "Start" ? LocalTime.MIDNIGHT : LocalTime.MAX;
+    }
+}
+
 private isDuringHoliday(currentHoliday) {
     def dates = getHolidayDates(currentHoliday);
-    def startTime = LocalDateTime.of(dates[0], getLocalTime("holidayStart") ?: LocalTime.MIDNIGHT);
-    def endTime = LocalDateTime.of(dates[1], getLocalTime("holidayStop") ?: LocalTime.MAX);
+    def startTime = LocalDateTime.of(dates[0],
+            getMaxTimePeriod("holiday", "Start")
+    );
+    def endTime = LocalDateTime.of(dates[1],
+            getMaxTimePeriod("holiday", "Stop")
+    );
     def now = LocalDateTime.now();
 
     return now.isAfter(startTime) && now.isBefore(endTime);


### PR DESCRIPTION
Avoids corner cases when using both times and modes for holidays. Previously would exclude holiday in either of these cases:

- Before the configured start time on the first day
- After the configured stop time on the last day

Notably, this does *not* re-evaluate the light mode at midnight, so lights still won't trigger until there's a mode change / configured time to prompt re-evaluation.