### PR TITLE
Handle hub outages, probably

### DIFF
--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -795,7 +795,18 @@ void beginStateMachine() {
         subscribe(location, "mode", "onModeChange");
     }
 
+    // Listen for hub reboots.
+    subscribe(location, "systemStart", "hubRestartHandler")
+
     // Figure out where we go from here.
+    determineNextLightMode();
+}
+
+private hubRestartHandler(evt) {
+    // Hub has rebooted -- we may have missed sunrise/sunset events
+    scheduleSunriseAndSunset();
+
+    // Make sure we're in the correct state for any time we've missed
     determineNextLightMode();
 }
 


### PR DESCRIPTION
This will trigger a re-evaluation on reboot, and _should_ properly schedule events for the upcoming sunrise/sunset if the `sunsetTime` event was missed.  However, it depends on being able to pull a correct `sunsetTime` event out of the hub's history, and I haven't tested that this happens when there's a protracted outage.