### PR TITLE
Better Suppression / Co-existence (#minor)

### DIFF
--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -1013,8 +1013,11 @@ private determineNextLightMode(event = null) {
     }
     else
     {
-        illuminationSwitch?.off();
-        otherIlluminationSwitches*.off();
+        if( illuminationSwitch?.currentValue("switch") == "on" ) {
+            debug("Illumination switch is on; turning off");
+            illuminationSwitch.off();
+        }
+        switchesOff(otherIlluminationSwitches);
         if ( isHoliday ) {
             if( state.test || isDuringHoliday(state.currentHoliday) ) {
                 debug("Holiday is active");
@@ -1036,7 +1039,7 @@ private determineNextLightMode(event = null) {
             }
         }
         else if ( isIllumination ) {
-            switchesForHoliday*.off();
+            switchesOff(switchesForHoliday);
             applyIlluminationSettings("untriggered");
         }
         else {
@@ -1080,7 +1083,7 @@ private applyIlluminationSettings(String prefix) {
             }
             debug("Setting color temperature to ${colorTemperature}K and level to ${level}%");
             ctDevices*.setColorTemperature(colorTemperature, level);
-            rgbOnlyDevices*.off();
+            switchesOff(rgbOnlyDevices);
             state.lightsActive = true;
             break;
         case RGB:
@@ -1231,11 +1234,15 @@ private lightsOff() {
     if( state.lightsActive ) {
         debug("Turning off lights");
         def devices = state.deviceIndices.collect{ settings["device${it}"] };
-        devices*.off();
-        otherIlluminationSwitches*.off();
-        switchesForHoliday*.off();
+        switchesOff(devices);
+        switchesOff(otherIlluminationSwitches);
+        switchesOff(switchesForHoliday);
         state.lightsActive = false;
     }
+}
+
+private switchesOff(switches) {
+    switches.findAll{ it.currentValue("switch") == "on" }*.off();
 }
 
 private manageTriggerSubscriptions(active, inactive, handler = null) {

--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -973,6 +973,7 @@ private triggerIllumination(event = null) {
     }
 
     state.illuminationMode = true;
+    state.lightsActive = true;
 
     // Turn on the illumination switch, but stop listening to on
     unsubscribe(illuminationSwitch, "switch.on");
@@ -1027,6 +1028,7 @@ private determineNextLightMode(event = null) {
                         !state.test
                 );
                 switchesForHoliday*.on();
+                state.lightsActive = true;
             }
             else {
                 debug("Holiday is not active");
@@ -1079,6 +1081,7 @@ private applyIlluminationSettings(String prefix) {
             debug("Setting color temperature to ${colorTemperature}K and level to ${level}%");
             ctDevices*.setColorTemperature(colorTemperature, level);
             rgbOnlyDevices*.off();
+            state.lightsActive = true;
             break;
         case RGB:
             def colorMap = null;
@@ -1098,9 +1101,10 @@ private applyIlluminationSettings(String prefix) {
             }
             debug("Setting color to ${colorMap.inspect()}");
             devices*.setColor(colorMap);
+            state.lightsActive = true;
             break;
         case OFF:
-            devices*.off();
+            lightsOff();
             break;
         default:
             error("Unknown illumination mode: ${mode}");
@@ -1224,11 +1228,14 @@ private getCurrentOrNextHoliday() {
 }
 
 private lightsOff() {
-    debug("Turning off lights");
-    def devices = state.deviceIndices.collect{ settings["device${it}"] };
-    devices*.off();
-    otherIlluminationSwitches*.off();
-    switchesForHoliday*.off();
+    if( state.lightsActive ) {
+        debug("Turning off lights");
+        def devices = state.deviceIndices.collect{ settings["device${it}"] };
+        devices*.off();
+        otherIlluminationSwitches*.off();
+        switchesForHoliday*.off();
+        state.lightsActive = false;
+    }
 }
 
 private manageTriggerSubscriptions(active, inactive, handler = null) {

--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -810,6 +810,7 @@ void beginStateMachine(event = null) {
         subscribe(location, "variable:${suspendVar}", "determineNextLightMode");
         addInUseGlobalVar(suspendVar);
     }
+    addInUseGlobalVar(holidayVar);
 
     // Basic subscriptions -- subscribe to switch changes and schedule begin/end
     // of other periods.

--- a/holiday-lights.groovy
+++ b/holiday-lights.groovy
@@ -810,7 +810,9 @@ void beginStateMachine(event = null) {
         subscribe(location, "variable:${suspendVar}", "determineNextLightMode");
         addInUseGlobalVar(suspendVar);
     }
-    addInUseGlobalVar(holidayVar);
+    if( holidayVar != null ) {
+        addInUseGlobalVar(holidayVar);
+    }
 
     // Basic subscriptions -- subscribe to switch changes and schedule begin/end
     // of other periods.


### PR DESCRIPTION
Fundamental changes here around better coexistence with other automations:
- If we previously turned all lights off, don't turn them off again (even if they've been turned on by something else in the meantime)
- If lights are already off, don't turn them off pointlessly.
- Allow setting a boolean variable which can be set when holiday lights are active, used to make RM/RL avoid stomping on holiday displays (previously done with a switch)

Note that this does not prevent re-sending desired state to lights which are already intended to be on (e.g. re-setting CT, re-applying a desired color, etc.).